### PR TITLE
New update-calculations flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test.db
 bench/*.db
 report.*
 output.log
+.vscode/

--- a/src/commands/update-calculations.ts
+++ b/src/commands/update-calculations.ts
@@ -2,6 +2,7 @@ import {
   createClient,
   fetchForm,
   fetchRecordsBySQL,
+  fetchRecordsByREST,
   fetchContext,
   saveRecords,
   batch,
@@ -39,7 +40,7 @@ export const handler = async ({
 
   const form = await fetchForm(client, formID);
 
-  const records = await fetchRecordsBySQL(client, form, sql ?? `select * from "${formID}"`);
+  const records = await fetchRecordsByREST(client, form);
 
   await batch(records, (record) => updateCalculations(record, context));
 


### PR DESCRIPTION
### What?

I have added the `fetchRecordsByREST` and `fetchAllRawRecords` functions to `api.ts` that allow the `update-calculations` command to collect records without using the QAPI. I have also changed the `commands` -> `update-calculations.ts` file to call `fetchRecordsByREST` instead of `fetchRecordsBySQL` in order to utilize this new functionality

### Why?

This way, records and projects don't need to be collected one at a time.

### Testing

I have not written any tests for this 😬 , but I have been testing in my personal org with a variety of calculation fields, including expressions that involve projects.